### PR TITLE
Create a Grafana Image Renderer egg

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ In this reposetory i collect some eggs for pterodactyl which i use for my person
 
 ### Services:
 - [nginx-fpm](/eggs/nginx-fpm/)
+- [grafana-image-renderer](/eggs/grafana-image-renderer/)
 
 ## DockerHub
 

--- a/eggs/grafana-image-renderer/README.md
+++ b/eggs/grafana-image-renderer/README.md
@@ -1,0 +1,4 @@
+# grafana-image-renderer
+Just import the .json in the **Nests** section of Pterodactyl.
+
+The Dockerfile is available here: [DockerHub](https://hub.docker.com/repository/docker/lazybytez/eggs/)

--- a/eggs/grafana-image-renderer/README.md
+++ b/eggs/grafana-image-renderer/README.md
@@ -2,3 +2,18 @@
 Just import the .json in the **Nests** section of Pterodactyl.
 
 The Dockerfile is available here: [DockerHub](https://hub.docker.com/repository/docker/lazybytez/eggs/)
+
+### Configuration
+Update your Grafana configuration to point to the right locations:
+```
+[rendering]
+server_url = http://localhost:8081/render
+callback_url = http://localhost:3000/
+```
+Replace `http://localhost:8081/render` with the address of your image renderer and `http://localhost:3000/` with the address of your
+Grafana instance. These settings have to be changed in your Grafanas defaults.ini (or grafana.ini).
+
+### Security
+The Grafana Image Renderer does not have any protection by default.
+It is strongly recommended to have a proper firewall setup on your server that restricts access
+to this application to trusted hosts.

--- a/eggs/grafana-image-renderer/README.md
+++ b/eggs/grafana-image-renderer/README.md
@@ -1,7 +1,7 @@
 # grafana-image-renderer
 Just import the .json in the **Nests** section of Pterodactyl.
 
-The Dockerfile is available here: [DockerHub](https://hub.docker.com/repository/docker/lazybytez/eggs/)
+The Dockerfile is available here: [DockerHub](https://hub.docker.com/r/lazybytez/eggs/tags?page=1&ordering=last_updated&name=grafana-image-renderer)
 
 ### Configuration
 Update your Grafana configuration to point to the right locations:

--- a/eggs/grafana-image-renderer/config.json
+++ b/eggs/grafana-image-renderer/config.json
@@ -1,0 +1,46 @@
+
+{
+    "service": {
+      "host": null,
+      "port": 8081,
+
+      "metrics": {
+        "enabled": false,
+        "collectDefaultMetrics": true,
+        "requestDurationBuckets": [1, 5, 7, 9, 11, 13, 15, 20, 30]
+      },
+
+      "logging": {
+        "level": "info",
+        "console": {
+          "json": true,
+          "colorize": false
+        }
+      }
+    },
+    "rendering": {
+      "chromeBin": null,
+      "args": [
+        "--no-sandbox"
+      ],
+      "ignoresHttpsErrors": false,
+
+      "timezone": null,
+      "acceptLanguage": null,
+      "width": 1000,
+      "height": 500,
+      "deviceScaleFactor": 1,
+      "maxWidth": 3080,
+      "maxHeight": 3000,
+      "maxDeviceScaleFactor": 3,
+
+      "mode": "default",
+      "clustering": {
+        "mode": "browser",
+        "maxConcurrency": 5
+      },
+
+      "verboseLogging": false,
+      "dumpio": false
+    }
+  }

--- a/eggs/grafana-image-renderer/egg-grafana-image-renderer.json
+++ b/eggs/grafana-image-renderer/egg-grafana-image-renderer.json
@@ -10,7 +10,7 @@
     "description": "The Grafana Image Renderer server as an Pterodactyl egg. Combined with the official Grafana egg, you Grafana instance can render images.",
     "features": null,
     "images": [
-        "lazybytez\/eggs:grafana-image-renderer-edge"
+        "lazybytez\/eggs:grafana-image-renderer"
     ],
     "file_denylist": [],
     "startup": "node \/usr\/src\/app\/build\/app.js server --config=\/home\/container\/config.json",

--- a/eggs/grafana-image-renderer/egg-grafana-image-renderer.json
+++ b/eggs/grafana-image-renderer/egg-grafana-image-renderer.json
@@ -1,0 +1,31 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v1",
+        "update_url": null
+    },
+    "exported_at": "2021-07-10T03:01:09+02:00",
+    "name": "Grafana Image Renderer",
+    "author": "p.zarrad@outlook.de",
+    "description": "The Grafana Image Renderer server as an Pterodactyl egg. Combined with the official Grafana egg, you Grafana instance can render images.",
+    "features": null,
+    "images": [
+        "lazybytez\/eggs:grafana-image-renderer-edge"
+    ],
+    "file_denylist": [],
+    "startup": "node \/usr\/src\/app\/build\/app.js server --config=\/home\/container\/config.json",
+    "config": {
+        "files": "{\r\n    \"config.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"service.host\": \"0.0.0.0\",\r\n            \"service.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
+        "startup": "{\r\n    \"done\": \"HTTP Server started, listening at\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "#!\/bin\/sh\r\n# Switch to mounted directory\r\ncd \/mnt\/server\r\nif [ ! -f \"config.json\" ]; then\r\n# Install curl\r\napk update\r\napk add --no-cache -y curl\r\n# Download default configuration file\r\ncurl https:\/\/raw.githubusercontent.com\/lazybytez\/custom-eggs\/master\/eggs\/grafana-image-renderer\/config.json --output config.json\r\nfi",
+            "container": "alpine:3.4",
+            "entrypoint": "ash"
+        }
+    },
+    "variables": []
+}

--- a/eggs/grafana-image-renderer/image/Dockerfile
+++ b/eggs/grafana-image-renderer/image/Dockerfile
@@ -1,11 +1,11 @@
 FROM grafana/grafana-image-renderer:latest
 
-LABEL author="Lazy Bytez" maintainer="contact@lazybytez.de"
+LABEL author="LazyBytez" maintainer="contact@lazybytez.de"
 
 RUN adduser -D -h /home/container container
-USER        container
-ENV         USER=container HOME=/home/container
-WORKDIR     /home/container
+USER container
+ENV USER=container HOME=/home/container
+WORKDIR /home/container
 
-COPY        ./entrypoint.sh /entrypoint.sh
-CMD         ["/bin/ash", "/entrypoint.sh"]
+COPY ./entrypoint.sh /entrypoint.sh
+CMD ["/bin/ash", "/entrypoint.sh"]

--- a/eggs/grafana-image-renderer/image/Dockerfile
+++ b/eggs/grafana-image-renderer/image/Dockerfile
@@ -1,0 +1,11 @@
+FROM grafana/grafana-image-renderer:latest
+
+LABEL author="Lazy Bytez" maintainer="contact@lazybytez.de"
+
+RUN adduser -D -h /home/container container
+USER        container
+ENV         USER=container HOME=/home/container
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+CMD         ["/bin/ash", "/entrypoint.sh"]

--- a/eggs/grafana-image-renderer/image/entrypoint.sh
+++ b/eggs/grafana-image-renderer/image/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/ash
+cd /home/container
+
+# Make internal Docker IP address available to processes.
+export INTERNAL_IP=`ip route get 1 | awk '{print $NF;exit}'`
+
+# Replace Startup Variables
+MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+echo ":/home/container$ ${MODIFIED_STARTUP}"
+
+# Run the Server
+eval ${MODIFIED_STARTUP}


### PR DESCRIPTION
## Description
Add an egg that provides the Grafana Image Renderer standalone server.

## Related issue
Resolves #18 

## How can this be tested?
Checkout if the Lazy Bytez internal Grafana and Grafana Image Renderer work together as expected.
