### PR TITLE
Use ghcr for images

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -1,0 +1,33 @@
+name: Publish Docker images
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  push:
+    branches:
+      - master
+      - feature/**
+
+jobs:
+  push_gir:
+    name: "Grafana Image Renderer"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+        with:
+          version: "v0.5.1"
+          buildkitd-flags: --debug
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: ./eggs/grafana-image-renderer/image
+          file: ./eggs/grafana-image-renderer/image/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/lazybytez/custom-eggs:gir

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - master
-      - feature/**
 
 jobs:
   push_gir:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ In this repository you find some custom eggs that do not fit in the official [pa
 - [grafana-image-renderer](/eggs/grafana-image-renderer/)
 - [mariadb-openssl](/eggs/mariadb-openssl)
 
-## DockerHub
-
-Here is the link to the Docker Hub repository with the Docker images: [https://hub.docker.com/r/lazybytez/eggs](https://hub.docker.com/r/lazybytez/eggs)
+## Docker Images
+Images used by the eggs of this repository can be found on ghcr.
+Refer to the packages section and choose [custom-eegs](https://github.com/lazybytez/custom-eggs/pkgs/container/custom-eggs) of the repository to see all available tags.
 
 ## Webservers and Nginx
-
 We had a `nginx / php` egg in this repository which has been removed. The NGINX egg did not reach the quality standard we wanted and was **not really secure**. The NGINX egg has been replaced with a Caddy egg that is way more configurable and secure.
 
 ## Contributing

--- a/eggs/grafana-image-renderer/egg-grafana-image-renderer.json
+++ b/eggs/grafana-image-renderer/egg-grafana-image-renderer.json
@@ -4,13 +4,13 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-08-05T23:15:32+02:00",
+    "exported_at": "2021-08-05T23:25:36+02:00",
     "name": "Grafana Image Renderer",
     "author": "contact@lazybytez.de",
     "description": "The Grafana Image Renderer server as an Pterodactyl egg. Combined with the official Grafana egg, you Grafana instance can render images.",
     "features": null,
     "images": [
-        "ghcr.io\/lazybytez\/ceggs:gir"
+        "ghcr.io\/lazybytez\/custom-eggs:gir"
     ],
     "file_denylist": [],
     "startup": "node \/usr\/src\/app\/build\/app.js server --config=\/home\/container\/config.json",

--- a/eggs/grafana-image-renderer/egg-grafana-image-renderer.json
+++ b/eggs/grafana-image-renderer/egg-grafana-image-renderer.json
@@ -4,13 +4,13 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-07-23T20:57:28+02:00",
+    "exported_at": "2021-08-05T23:15:32+02:00",
     "name": "Grafana Image Renderer",
     "author": "contact@lazybytez.de",
     "description": "The Grafana Image Renderer server as an Pterodactyl egg. Combined with the official Grafana egg, you Grafana instance can render images.",
     "features": null,
     "images": [
-        "lazybytez\/eggs:grafana-image-renderer"
+        "ghcr.io\/lazybytez\/ceggs:gir"
     ],
     "file_denylist": [],
     "startup": "node \/usr\/src\/app\/build\/app.js server --config=\/home\/container\/config.json",

--- a/eggs/grafana-image-renderer/image/Dockerfile
+++ b/eggs/grafana-image-renderer/image/Dockerfile
@@ -1,3 +1,4 @@
+# Note: This image should only being build for linux/amd64
 FROM --platform=$BUILDPLATFORM grafana/grafana-image-renderer:latest
 
 LABEL author="LazyBytez" maintainer="contact@lazybytez.de"


### PR DESCRIPTION
## Description
Switch from Docker Hub to ghcr for our custom Docker images.