### PR TITLE
Use the right placeholder for the port

### DIFF
--- a/eggs/caddy/config/Caddyfile
+++ b/eggs/caddy/config/Caddyfile
@@ -1,4 +1,4 @@
-:{{PTERODACTYL_PORT}} {
+{{PTERODACTYL_PORT}} {
 	root * /home/container/www
 	encode zstd gzip
 	file_server


### PR DESCRIPTION
## Description
Use the right placeholder for the port as the colon prevents proper automated configuration