### PR TITLE
Remove explizit iconv installation from PHP images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
-# Custom Eggs
+<div align="center">
+
+# Lazy Bytez Custom Eggs
+
+![license-info][license-info]
+![discord-info][discord-info]
+
+![commit-info][commit-info]
+![contributors-info][contributors-info]
+![reposize-info][reposize-info]
+![stars][stars]
+
+</div>
+
+## Description
 In this repository you find some custom eggs that do not fit in the official [parkervcp/eggs](https://github.com/parkervcp/eggs) repository like webservers or very specific software.
 
 ## Links to Eggs
@@ -38,3 +52,11 @@ If you want to take part in contribution, like fixing issues and contributing di
 [github-issues]: https://github.com/lazybytez/eggs/issues
 [github-pulls]: https://github.com/lazybytez/eggs/pulls
 [github-security]: https://github.com/lazybytez/eggs/blob/master/SECURITY.md
+
+
+[license-info]: https://img.shields.io/github/license/lazybytez/custom-eggs?logo=gnu&style=for-the-badge&colorA=302D41&colorB=f9e2af&logoColor=f9e2af
+[discord-info]: https://img.shields.io/discord/735171597362659328?label=Discord&logo=discord&logoColor=b4befe&style=for-the-badge&colorA=302D41&colorB=b4befe
+[commit-info]: https://img.shields.io/github/last-commit/lazybytez/custom-eggs?style=for-the-badge&colorA=302D41&colorB=b4befe
+[contributors-info]: https://img.shields.io/github/contributors/lazybytez/custom-eggs?style=for-the-badge&colorA=302D41&colorB=cba6f7
+[reposize-info]: https://img.shields.io/github/repo-size/lazybytez/custom-eggs?style=for-the-badge&colorA=302D41&colorB=89dceb
+[stars]: https://img.shields.io/github/stars/lazybytez/custom-eggs?colorA=302D41&colorB=f9e2af&style=for-the-badge

--- a/eggs/caddy-php/image/7.3/Dockerfile
+++ b/eggs/caddy-php/image/7.3/Dockerfile
@@ -64,7 +64,6 @@ RUN docker-php-ext-install \
         mysqli \
         gd \
         fileinfo \
-        iconv \
         phar \
         simplexml \
         xml \

--- a/eggs/caddy-php/image/7.3_composer1/Dockerfile
+++ b/eggs/caddy-php/image/7.3_composer1/Dockerfile
@@ -64,7 +64,6 @@ RUN docker-php-ext-install \
         mysqli \
         gd \
         fileinfo \
-        iconv \
         phar \
         simplexml \
         xml \

--- a/eggs/caddy-php/image/7.4/Dockerfile
+++ b/eggs/caddy-php/image/7.4/Dockerfile
@@ -59,7 +59,6 @@ RUN docker-php-ext-install \
         mysqli \
         gd \
         fileinfo \
-        iconv \
         phar \
         simplexml \
         xml \

--- a/eggs/caddy-php/image/7.4_composer1/Dockerfile
+++ b/eggs/caddy-php/image/7.4_composer1/Dockerfile
@@ -59,7 +59,6 @@ RUN docker-php-ext-install \
         mysqli \
         gd \
         fileinfo \
-        iconv \
         phar \
         simplexml \
         xml \

--- a/eggs/caddy-php/image/8.0/Dockerfile
+++ b/eggs/caddy-php/image/8.0/Dockerfile
@@ -58,7 +58,6 @@ RUN CFLAGS="$CFLAGS -D_GNU_SOURCE" docker-php-ext-install \
         mysqli \
         gd \
         fileinfo \
-        iconv \
         phar \
         simplexml \
         xml \

--- a/eggs/caddy-php/image/8.0_composer1/Dockerfile
+++ b/eggs/caddy-php/image/8.0_composer1/Dockerfile
@@ -58,7 +58,6 @@ RUN CFLAGS="$CFLAGS -D_GNU_SOURCE" docker-php-ext-install \
         mysqli \
         gd \
         fileinfo \
-        iconv \
         phar \
         simplexml \
         xml \

--- a/eggs/caddy-php/image/8.1/Dockerfile
+++ b/eggs/caddy-php/image/8.1/Dockerfile
@@ -57,7 +57,6 @@ RUN CFLAGS="$CFLAGS -D_GNU_SOURCE" docker-php-ext-install \
         mysqli \
         gd \
         fileinfo \
-        iconv \
         phar \
         simplexml \
         xml \

--- a/eggs/caddy-php/image/8.1_composer1/Dockerfile
+++ b/eggs/caddy-php/image/8.1_composer1/Dockerfile
@@ -57,7 +57,6 @@ RUN CFLAGS="$CFLAGS -D_GNU_SOURCE" docker-php-ext-install \
         mysqli \
         gd \
         fileinfo \
-        iconv \
         phar \
         simplexml \
         xml \


### PR DESCRIPTION
## Description
Remove explizit iconv installation from PHP images

Additionally the README has been updated with some nicer design.

## Related issue
Fixes #49 