### PR TITLE
 Add our own jojo discord bot as an egg 

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -67,3 +67,31 @@ jobs:
           push: true
           tags: |
             ghcr.io/lazybytez/custom-eggs:php_${{ matrix.tag }}
+
+  push_jojo_bot:
+    name: "JoJo Discord Bot ${{ matrix.tag }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - "stable"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-buildx-action@v1
+        with:
+          version: "v0.5.1"
+          buildkitd-flags: --debug
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: ./eggs/jojo-discord-bot/image
+          file: ./eggs/jojo-discord-bot/image/${{ matrix.tag }}/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/lazybytez/custom-eggs:jojo-discord-bot_${{ matrix.tag }}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ on the official Pterodactyl Discord! Use **our repo or Discord** for support!_
 - [grafana-image-renderer](/eggs/grafana-image-renderer/)
 - [mariadb-openssl](/eggs/mariadb-openssl)
 
+### Discord Bots
+
+- [JoJo](/eggs/jojo-discord-bot/)
+
 ## Docker Images
 
 Images used by the eggs of this repository can be found on ghcr. Refer to the packages section and

--- a/eggs/jojo-discord-bot/README.md
+++ b/eggs/jojo-discord-bot/README.md
@@ -1,0 +1,16 @@
+# JoJo Discord Bot
+A egg for our own Discord Bot which can be found here: https://github.com/lazybytez/jojo-discord-bot
+
+### Installation
+Just import the .json in the **Nests** section of Pterodactyl.
+
+### Configuration
+The only configuration you need is the **Discord Bot Token**. 
+
+**Discord Bot Token**
+The Token needs to be added as an env variable. This means you just need to copy the token into the only empty config field. 
+
+### Important
+
+This egg is not offically supported by Pterodactyl.  
+The reason why whe created this is to stress-test our discord bot as a stage instance.

--- a/eggs/jojo-discord-bot/image/entrypoint.sh
+++ b/eggs/jojo-discord-bot/image/entrypoint.sh
@@ -1,0 +1,21 @@
+# Default the TZ environment variable to UTC.
+TZ=${TZ:-UTC}
+export TZ
+
+# Set environment variable that holds the Internal Docker IP
+INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export INTERNAL_IP
+
+# Switch to the container's working directory
+cd /home/container || exit 1
+
+# Convert all of the "{{VARIABLE}}" parts of the command into the expected shell
+# variable format of "${VARIABLE}" before evaluating the string and automatically
+# replacing the values.
+PARSED=$(echo "${STARTUP}" | sed -e 's/{{/${/g' -e 's/}}/}/g' | eval echo "$(cat -)")
+
+# Display the command we're running in the output, and then execute it with the env
+# from the container itself.
+printf "\033[1m\033[33mcontainer@pterodactyl~ \033[0m%s\n" "$PARSED"
+# shellcheck disable=SC2086
+exec env ${PARSED}

--- a/eggs/jojo-discord-bot/image/stable/Dockerfile
+++ b/eggs/jojo-discord-bot/image/stable/Dockerfile
@@ -1,0 +1,16 @@
+FROM --platform=$BUILDPLATFORM ghcr.io/lazybytez/jojo-discord-bot:latest
+
+LABEL author="LazyBytez" maintainer="contact@lazybytez.de"
+
+LABEL org.opencontainers.image.source="https://github.com/lazybytez/custom-eggs"
+LABEL org.opencontainers.image.licenses=MIT
+
+# Add container user
+RUN adduser -D -h /home/container container
+
+USER container
+ENV USER=container HOME=/home/container
+WORKDIR /home/container
+
+COPY ./../entrypoint.sh /entrypoint.sh
+entrypoint [ "/bin/ash", "/entrypoint.sh" ]

--- a/eggs/jojo-discord-bot/jojo-discord-bot.json
+++ b/eggs/jojo-discord-bot/jojo-discord-bot.json
@@ -1,0 +1,42 @@
+{
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
+    "meta": {
+        "version": "PTDL_v2",
+        "update_url": null
+    },
+    "exported_at": "2022-08-02T20:52:08+02:00",
+    "name": "JoJo Discord Bot",
+    "author": "elias.knodel@gmail.com",
+    "description": "A pterodactyl egg for the jojo-discord-bot.",
+    "features": null,
+    "docker_images": {
+        "ghcr jojo-discord-bot": "ghcr.io\/lazybytez\/custom-eggs:jojo-discord-bot_stable"
+    },
+    "file_denylist": [],
+    "startup": "\/app\/jojo-discord-bot",
+    "config": {
+        "files": "{}",
+        "startup": "{\r\n    \"done\": \"Bot is running.\"\r\n}",
+        "logs": "{}",
+        "stop": "^C"
+    },
+    "scripts": {
+        "installation": {
+            "script": "",
+            "container": "alpine:latest",
+            "entrypoint": "ash"
+        }
+    },
+    "variables": [
+        {
+            "name": "Discord Bot Token",
+            "description": "Your private Discord Bot Token.",
+            "env_variable": "DISCORD_BOT_TOKEN",
+            "default_value": "example.veryunreadablenumberandcharactercombination123",
+            "user_viewable": true,
+            "user_editable": true,
+            "rules": "required|string|max:128",
+            "field_type": "text"
+        }
+    ]
+}


### PR DESCRIPTION
## Description

Adds our own discord bot (https://github.com/lazybytez/jojo-discord-bot) as a pterodactyl egg.